### PR TITLE
Adding a way to disable all proxy processing (#691)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ These are the available config options for making requests. Only the `url` is re
   httpsAgent: new https.Agent({ keepAlive: true }),
 
   // 'proxy' defines the hostname and port of the proxy server
+  // Use `false` to disable proxies, ignoring environment variables.
   // `auth` indicates that HTTP Basic auth should be used to connect to the proxy, and
   // supplies credentials.
   // This will set an `Proxy-Authorization` header, overwriting any existing

--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -82,7 +82,7 @@ module.exports = function httpAdapter(config) {
     };
 
     var proxy = config.proxy;
-    if (!proxy) {
+    if (!proxy && proxy !== false) {
       var proxyEnv = protocol.slice(0, -1) + '_proxy';
       var proxyUrl = process.env[proxyEnv] || process.env[proxyEnv.toUpperCase()];
       if (proxyUrl) {

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -311,6 +311,23 @@ module.exports = {
     });
   },
 
+  testHTTPProxyDisabled: function(test) {
+    // set the env variable
+    process.env.http_proxy = 'http://does-not-exists.example.com:4242/';
+
+    server = http.createServer(function(req, res) {
+      res.setHeader('Content-Type', 'text/html; charset=UTF-8');
+      res.end('123456789');
+    }).listen(4444, function() {
+      axios.get('http://localhost:4444/', {
+          proxy: false
+        }).then(function(res) {
+          test.equal(res.data, '123456789', 'should not pass through proxy');
+          test.done();
+        });
+    });
+  },
+
   testHTTPProxyEnv: function(test) {
     server = http.createServer(function(req, res) {
       res.setHeader('Content-Type', 'text/html; charset=UTF-8');


### PR DESCRIPTION
* Adding a way to disable all proxy processing

When the proxy field in configuration is === false all proxy processing is
disabled. This specifically disable the 'http_proxy' environment variable
handling.

Fixes #635
Related to #434

* Change readme wording

From review comment on PR (#691)

<!-- Click "Preview" for a more readable version -->

#### Instructions

Please read and follow this instructions before creating and submitting a pull request:

- Create an issue explaining the feature. It could save you some effort in case we don't consider it should be included in axios.
- If you're fixing a bug, try to commit the failing test/s and the code fixing it in different commits.
- Ensure you're following our [contributing guide](https://github.com/mzabriskie/axios/blob/master/CONTRIBUTING.md).

*^^^ Delete the instructions before submitting the pull request ^^^*

Describe your pull request here.
